### PR TITLE
add instructions about how to understand the performance of sync server and scale it

### DIFF
--- a/sync_configuration_guide.adoc
+++ b/sync_configuration_guide.adoc
@@ -1,0 +1,65 @@
+[[sync_configuration_guide]]
+
+= Sync Configuration Guide
+
+== Overview
+
+The sync framework offer quite a few configuration options to allow developers to control the behaviour of the sync server.
+This document will explain how to determine the right value for some of those configuration options.
+
+== Configuring Frequency of the Sync Server
+
+You can configure a different sync frequency on the client and on the server.
+In this section, we will focus on how to decide the best value for the sync frequency on the server.
+
+The sync frequency value of a server will determine how often the sync processor runs.
+It is the time the system should wait between 2 sync processes.
+Every time the sync processor executes, it will perform a list operation on the Dataset Backend to synchronize the data with a local copy.
+To determine the best value of the sync frequency, here are the few things you should consider:
+
+=== How quickly do you want your clients to see changes from others?
+
+When a client submits changes, those changes are performed against the Dataset Backend directly.
+However, for other clients, they are getting the data from the local copy (for performance reasons).
+This means other clients will only be able to get the new changes after the next sync processor runs.
+If it's important for other clients to see the changes as soon as possible, then you should consider setting a low value for the sync frequency.
+
+=== How long it takes the sync processor to run?
+
+The sync frequency value will decide how long the system should wait between sync processor executions.
+The sync frequency is the time from the completion of the one execution to the start time of next execution.
+This means there will never be a situation where 2 sync processors will be running at the same time.
+It also means:
+
+  actual sync frequency = sync processor execution time + the sync frequency
+
+
+This will help you to calculate the number of requests the system will make to the Dataset Backend.
+
+To know how long each sync processor execution takes, you can query the sync stats endpoint to see the average `Job Process Time` it takes for the `sync_worker` to complete.
+
+=== How much load can the Dataset Backend service handle?
+
+As mentioned above, everytime when the sync processor runs, it will perform a list operation on the Dataset Backend.
+When you setup the sync frequency, you should be able to estimate how many requests it will generate on your backend, and make sure the backend can handle the load.
+
+For example, if you set the sync frequency of a dataset to be 100ms, and each sync processor execution is taking 100ms to run, that means the server will generate about 5 req/sec to your backend.
+However, if you have another dataset with the same frequency that uses the same backend, it means there will be about 10 req/sec to the backend.
+The rate will be fairly consistent, so you can perform load tests against the backend to determine if your backend can handle that much load.
+
+However, its worth mentioning that this value will not grow when you scale the app.
+For example, if you have multiple workers in your server, the sync processor executions are distributed among the workers rather than duplicated among them.
+This is by design to protect the backend when the app is under heavy load.
+
+=== How much extra load it will cause to the server itself?
+
+When the data is returned from the backend, the server will have to save the data to the local storage (MongoDB).
+The system is smart enough to only perform updates if there are changes.
+But it needs to perform a read operation first to get the current data in the local storage first.
+When there are a lot of sync processor executions, it could cause extra load on the server itself.
+Sometimes you may need to take this into consideration especially if the dataset's size is relatively large.
+
+To understand performance of the server, you can use the sync stats endpoint to check the CPU usages, and the MongoDB operation time to determine if the server is under heavy load.
+
+To summarise, you can use the sync frequency value to control the number of requests the server will generate to your backend.
+It is perfectly fine to set it to 0, as long as the backend can handle the load, and the server itself is not over-loaded.

--- a/sync_performance_scaling_guide.adoc
+++ b/sync_performance_scaling_guide.adoc
@@ -15,7 +15,7 @@ The sync server provides 2 options for you to inspect the performance of itself:
 === 1. Query the `/mbaas/sync/stats` endpoint
 
 By default, the sync framework will save its metrics data into Redis while it's running. 
-You can then send a HTTP GET request to the `/mbaas/sync/status` endpoint to view the summary of those metrics data. 
+You can then send a HTTP GET request to the `/mbaas/sync/stats` endpoint to view the summary of those metrics data. 
 
 The following information is available from this endpoint:
 
@@ -38,7 +38,6 @@ If you want to visualize the current and historical metrics data, you can instru
 
 There are plenty of tutorials online to help setup InfluxDB and Grafana. For example:
 
-* http://www.netinstructions.com/installing-influxdb-and-grafana-on-an-ec2-instance/[How to setup InfluxDB and Grafana on AWS EC2]
 * https://github.com/feedhenry/sync-metrics-openshift[How to setup InfluxDB and Grafana on OpenShift]
 
 Once you have InfluxDB running, you just need to update the following configurations to instruct the sync server to send metrics data:

--- a/sync_performance_scaling_guide.adoc
+++ b/sync_performance_scaling_guide.adoc
@@ -1,66 +1,119 @@
 [[sync-performance-scaling-guide]]
-= Sync Performance & Scaling Guide
+= Sync Server Performance & Scaling Guide
 
-== Configuring Frequency of the Sync Server
+== Overview
 
-You can configure a different sync frequency on the client and on the server.
-In this section, we will focus on how to decide the best value for the sync frequency on the server.
+The sync server is designed to be scalable.
+In order for you to decide if scaling is required, you need to know how it performs first. 
 
-The sync frequency value of a server will determine how often the sync processor runs.
-It is the time the system should wait between 2 sync processes.
-Every time the sync processor executes, it will perform a list operation on the Dataset Backend to synchronize the data with a local copy.
-To determine the best value of the sync frequency, here are the few things you should consider:
+This guide will help you to understand the performance of the sync server, and the options to scale.
 
-=== How quickly do you want your clients to see changes from others?
+== Inspecting the performance
 
-When a client submits changes, those changes are performed against the Dataset Backend directly.
-However, for other clients, they are getting the data from the local copy (for performance reasons).
-This means other clients will only be able to get the new changes after the next sync processor runs.
-If it's important for other clients to see the changes as soon as possible, then you should consider setting a low value for the sync frequency.
+The sync server provides 2 options for you to inspect the performance of itself:
 
-=== How long it takes the sync processor to run?
+=== 1. Query the `/mbaas/sync/stats` endpoint
 
-The sync frequency value will decide how long the system should wait between sync processor executions.
-The sync frequency is the time from the completion of the one execution to the start time of next execution.
-This means there will never be a situation where 2 sync processors will be running at the same time.
-It also means:
+By default, the sync framework will save its metrics data into Redis while it's running. 
+You can then send a HTTP GET request to the `/mbaas/sync/status` endpoint to view the summary of those metrics data. 
 
-  actual sync frequency = sync processor execution time + the sync frequency
+The following information is available from this endpoint:
 
+* CPU & Memory Usage of all the workers
+* The time taken to process various jobs
+* The number of the remaining jobs in various job queues
+* The time taken for various API calls
+* The time taken forvarious MongoDB operations
 
-This will help you to calculate the number of requests the system will make to the Dataset Backend.
+For each of those metrics, you will be able to see the total number of samples, the current, maximum, minimum and average values. 
 
-To know how long each sync processor execution takes, you can query the sync stats endpoint to see the average `Job Process Time` it takes for the `sync_worker` to complete.
+By default, it will collect the last 1000 samples for each metric, but you can control that using the `statsRecordsToKeep` configuration option.
 
-=== How much load can the Dataset Backend service handle?
+This endpoint is easy to use and will provide enough information for you to understand the current performance of the sync server. 
+However, if you want to visualize and understand the performance over a period of time, you should consider the next option.
 
-As mentioned above, everytime when the sync processor runs, it will perform a list operation on the Dataset Backend.
-When you setup the sync frequency, you should be able to estimate how many requests it will generate on your backend, and make sure the backend can handle the load.
+=== 2. Visualize the metrics data with InfluxDB and Grafana
 
-For example, if you set the sync frequency of a dataset to be 100ms, and each sync processor execution is taking 100ms to run, that means the server will generate about 5 req/sec to your backend.
-However, if you have another dataset with the same frequency that uses the same backend, it means there will be about 10 req/sec to the backend.
-The rate will be fairly consistent, so you can perform load tests against the backend to determine if your backend can handle that much load.
+If you want to visualize the current and historical metrics data, you can instruct the sync server to send the metrics data to InfluxDB, and see the graphs in Grafana.
 
-However, its worth mentioning that this value will not grow when you scale the app.
-For example, if you have multiple workers in your server, the sync processor executions are distributed among the workers rather than duplicated among them.
-This is by design to protect the backend when the app is under heavy load.
+There are plenty of tutorials online to help setup InfluxDB and Grafana. For example:
 
-=== How much extra load it will cause to the server itself?
+* http://www.netinstructions.com/installing-influxdb-and-grafana-on-an-ec2-instance/[How to setup InfluxDB and Grafana on AWS EC2]
+* https://github.com/feedhenry/sync-metrics-openshift[How to setup InfluxDB and Grafana on OpenShift]
 
-When the data is returned from the backend, the server will have to save the data to the local storage (MongoDB).
-The system is smart enough to only perform updates if there are changes.
-But it needs to perform a read operation first to get the current data in the local storage first.
-When there are a lot of sync processor executions, it could cause extra load on the server itself.
-Sometimes you may need to take this into consideration especially if the dataset's size is relatively large.
+Once you have InfluxDB running, you just need to update the following configurations to instruct the sync server to send metrics data:
 
-To understand performance of the server, you can use the sync stats endpoint to check the CPU usages, and the MongoDB operation time to determine if the server is under heavy load.
+* metricsInfluxdbHost
+* metricsInfluxdbPort
 
-To summarise, you can use the sync frequency value to control the number of requests the server will generate to your backend.
-It is perfectly fine to set it to 0, as long as the backend can handle the load, and the server itself is not over-loaded.
+[NOTE]
+====
+Please make sure `metricsInfluxdbPort` is a UDP port
+====
 
-== Scaling on OpenShift
+To see the metrics data graph in Grafana, you will need to create a new dashboard with graphs first. 
+The quickest way is to import https://github.com/feedhenry/sync-metrics-openshift/blob/master/dashboards/sync-stats.json[this Grafana databoard file].
+Once the app is running, you should start to see metrics data in the Grafana dashboard.
+
+For more details about how to configure the Grafana graphs, please refer to the http://docs.grafana.org/[Grafana Documentation].
+
+== Understanding the performance
+
+To understand the performance of the sync server, here are some of the key metrics you need to look at:
+
+=== CPU usages
+
+This is the most important metric. 
+On one hand, if CPU is over loaded, then the sync server will not be able to respond to the client requests.
+On the other hand, we want to utilize the CPU usage as much as possible.
+
+To balance that, we should establish a threshold to determine when to scale the sync server. The recommended value is 80%.
+
+If CPU utilization is below that, the sync server doesn't need scale, and you can probably reduce a few worker interval configurations to increase the CPU usages.
+However, if CPU usage is above that threshold, you should definitely consider scaling the sync server.
+
+=== Remaining jobs in various queues
+
+The sync server will save various jobs in queues and process them later. 
+
+If there are many jobs left in the queues and the number keeps growing, and the CPU utilization is relatively low, you should reduce worker interval configurations to process the jobs quicker.
+
+Otherwise, if the sync server is already under heave load, you should consider scaling the sync server to allow new workers to be created to process the jobs.
+
+=== API response time
+
+If you observe increases in the reponse time for various sync APIs, and the CPU usage is going up, it means the sync server is under load.
+At this point, you should consider scale it.
+
+However, if the CPU usage doesn't change much, it normally means something else is causing the slow down, and you should investigate the problem.
+
+=== MongoDB operation time
+
+In a production environment, the time for various MongoDB operations should be relatively low and consistent.
+If you start observing increases of time for those operations, it could mean the sync server is generating too many operations on the MongoDB and starts to reach the limit of MongoDB.
+
+In this case, scaling the sync server will not really help, because the bottleneck is in MongoDB. There are a few options you can consider:
+
+* Turn on caching by setting the `useCache` flag to true. This should reduce the number of db requests to read dataset records.
+* Increase the various worker intervals and sync frequencies.
+* If possible, scale MongoDB.
+
+== Scaling the Sync Server
+
+If you decide to scale the sync server, here are some of the options you can consider:
+
+=== Scaling on Dynofarm
+
+If your app is running on the RHMAP dynofarm (all the SAAS customers are), you can use https://nodejs.org/docs/latest-v4.x/api/cluster.html[Nodejs Clustering] to create more workers.
+
+If that's not enough, it is possible to create another app and point it to the same MongoDB to scale even further. 
+
+//TODO: Add instruction of how to do that.
+
+=== Scaling on OpenShift
 
 The best way to scale the application on OpenShift is to use the auto scaling feature.
+
 In order to do that, you first have to make sure metrics is enabled in the OpenShift cluster, and then use the `oc autoscale` command to configure when the application should be scaled.
 
 For example, on OpenShift 3.2, here is the document of how to https://docs.openshift.com/enterprise/3.2/install_config/cluster_metrics.html#metrics-deployer[enable cluster metrics].


### PR DESCRIPTION
This PR:

* added a new sync_configuration_guide.adoc and move the `Configuring Frequency of the Sync Server` section to there. Plan to add more there for other configuration options.
* updated the sync performance and scale guide to add more information about how to inspect and understand the performance of the sync server, and how to scale it.

ping @david-martin  for review.