### PR TITLE
Remove Appcelerator References

### DIFF
--- a/auth.adoc
+++ b/auth.adoc
@@ -24,7 +24,6 @@ image:ios_oauth_sample.png[iOS_OAuth_Sample.png]
 * JavaScript SDK
 ** Cordova
 ** Web Apps
-** Appcelerator
 * Android SDK
 * iOS Objective-C SDK
 * iOS Swift SDK

--- a/cloud.adoc
+++ b/cloud.adoc
@@ -17,7 +17,6 @@ For example, if you are using Express to defined endpoints in your Cloud Apps, y
 * JavaScript SDK
 ** Cordova
 ** Web Apps
-** Appcelerator
 * Android SDK
 * iOS Objective-C SDK
 * iOS Swift SDK

--- a/cloud_app_url.adoc
+++ b/cloud_app_url.adoc
@@ -20,7 +20,6 @@ To make it easier, the SDKs also have APIs to provide this meta data as request 
 * JavaScript SDK
 ** Cordova
 ** Web Apps
-** Appcelerator
 * Android SDK
 * iOS Objective-C SDK
 * iOS Swift SDK

--- a/default_params.adoc
+++ b/default_params.adoc
@@ -30,7 +30,6 @@ Some SDKs can provide this meta data as request headers. In this case, the name 
 * JavaScript SDK
 ** Cordova
 ** Web Apps
-** Appcelerator
 * Android SDK
 * iOS Objective-C SDK
 * iOS Swift SDK

--- a/forms_client_api.adoc
+++ b/forms_client_api.adoc
@@ -9,7 +9,6 @@ include::shared/attributes.adoc[]
 * JavaScript SDK
 ** Cordova
 ** Web Apps
-** Appcelerator
 
 For detailed version information, see link:https://access.redhat.com/node/2357761[Supported Configurations^].
 

--- a/hash_client_api.adoc
+++ b/hash_client_api.adoc
@@ -16,7 +16,6 @@ Generate hash value of a string.
 * JavaScript SDK
 ** Cordova
 ** Web Apps
-** Appcelerator
 
 For detailed version information, see link:https://access.redhat.com/node/2357761[Supported Configurations^].
 

--- a/init.adoc
+++ b/init.adoc
@@ -13,7 +13,6 @@ The initializations process involves a call to the server to verify that it is a
 * JavaScript SDK
 ** Cordova
 ** Web Apps
-** Appcelerator
 * Android SDK
 * iOS Objective-C SDK
 * iOS Swift SDK

--- a/push_client_api.adoc
+++ b/push_client_api.adoc
@@ -15,7 +15,6 @@ Register with the server to start receiving push notifications.
 
 * JavaScript SDK
 ** Cordova
-** Appcelerator
 * Android SDK
 * iOS Objective-C SDK
 * iOS Swift SDK

--- a/sec_client_api.adoc
+++ b/sec_client_api.adoc
@@ -16,7 +16,6 @@ Key pair generation and data encryption and decryption.
 * JavaScript SDK
 ** Cordova
 ** Web Apps
-** Appcelerator
 
 For detailed version information, see link:https://access.redhat.com/node/2357761[Supported Configurations^].
 

--- a/sync_client_api.adoc
+++ b/sync_client_api.adoc
@@ -12,7 +12,6 @@ The Sync client uses events to notify the app when data state has changed, such 
 
 * JavaScript SDK
 ** Cordova
-** Appcelerator
 ** Web Apps
 * Android SDK
 * iOS Objective-C SDK


### PR DESCRIPTION
As per ticket [FH-3250](https://issues.jboss.org/browse/FH-3250) we are no longer supporting Titanium/appcelerator apps. Removing all references in the repos also

@jcesarmobile @corinnekrych 