### PR TITLE
Fh 3446 new sync api doc

### DIFF
--- a/sync_cloud_api/connect.adoc
+++ b/sync_cloud_api/connect.adoc
@@ -1,9 +1,9 @@
 [[fh-sync-connect]]
 == $fh.sync.connect
 
-Make sure the sync server is connected to the requried dependent resources, like MongoDB and Redis.
+Make sure the sync server is connected to the requried dependent resources i.e. MongoDB and Redis.
 
-NOTE: You don't need to invoke this if you are using the fh-mbaas-api module in your app, it will be called automatically.
+NOTE: When using the sync server from `fh-mbaas-api`, `sync.connect` is called automatically, and told to use the Cloud App's database. There is no need to call `sync.connect` in this case.
 
 === Usage
 
@@ -15,7 +15,7 @@ $fh.sync.connect(mongodbConnectionString, mongodbConf, redisConnectionString, ca
 === Parameters
 
 ==== mongodbConnectionString
-* Description: The connection url of MongoDB
+* Description: The connection url of MongoDB. The url is passed straight to the `mongodb` module.
 * Type: String
 
 ==== mongodbConf
@@ -31,7 +31,7 @@ However, you can still control some of the MongoDB connection options via enviro
 * Type: Object
 
 ==== redisConnectionString
-* Description: The connection url of Redis. Should include authentication info if required.
+* Description: The connection url of Redis. Should include authentication info if required. The url is passed straight to the `redis` module.
 * Type: String
 
 ==== callback

--- a/sync_cloud_api/connect.adoc
+++ b/sync_cloud_api/connect.adoc
@@ -1,0 +1,55 @@
+[[fh-sync-connect]]
+== $fh.sync.connect
+
+Make sure the sync server is connected to the requried dependent resources, like MongoDB and Redis.
+
+NOTE: You don't need to invoke this if you are using the fh-mbaas-api module in your app, it will be called automatically.
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.connect(mongodbConnectionString, mongodbConf, redisConnectionString, callback)
+----
+
+=== Parameters
+
+==== mongodbConnectionString
+* Description: The connection url of MongoDB
+* Type: String
+
+==== mongodbConf
+* Description: The MongoDB connection options. For more details of this option, please check http://mongodb.github.io/node-mongodb-native/2.1/api/MongoClient.html[MongoClient.connect API doc].
++
+As mentioned above, in most cases you don't need to call this function. 
+However, you can still control some of the MongoDB connection options via environment variables:
++
+** SYNC_MONGODB_POOLSIZE
+*** Description: Specify the MongoDB connection pool size
+*** Type: Number
+*** Default: 50
+* Type: Object
+
+==== redisConnectionString
+* Description: The connection url of Redis. Should include authentication info if required.
+* Type: String
+
+==== callback
+* Description: the callback function
+* Type: function
+
+=== Example
+
+[source,javascript]
+----
+var mongodbUrl = "mongodb://mongouser:mongopass@127.0.0.1";
+var redisUrl = "redis://redisuser:redispass@127.0.0.1";
+
+$fh.sync.connect(mongodbUrl, {}, redisUrl, function(err){
+  if (err) {
+    console.error('Connection error for sync', err);
+  } else {
+    console.log('sync connected');
+  }
+});
+----

--- a/sync_cloud_api/getEventEmitter.adoc
+++ b/sync_cloud_api/getEventEmitter.adoc
@@ -3,7 +3,7 @@
 
 Get the event emitter of the sync server. 
 
-It will return the same emitter instance as `$fh.events`.
+If using sync from `fh-mbaas-api`, it will return the same emitter instance as `$fh.events`.
 
 === Usage
 

--- a/sync_cloud_api/getEventEmitter.adoc
+++ b/sync_cloud_api/getEventEmitter.adoc
@@ -1,0 +1,27 @@
+[[fh-sync-geteventemitter]]
+== $fh.sync.getEventEmitter
+
+Get the event emitter of the sync server. 
+
+It will return the same emitter instance as `$fh.events`.
+
+=== Usage
+
+[source,javascript]
+----
+var emitter = $fh.sync.getEventEmitter();
+----
+
+=== Parameters
+
+None.
+
+=== Example
+
+[source,javascript]
+----
+var emitter = $fh.sync.getEventEmitter();
+emitter.once('sync:ready', function(){
+  //do something here
+});
+----

--- a/sync_cloud_api/globalHandleCollision.adoc
+++ b/sync_cloud_api/globalHandleCollision.adoc
@@ -1,0 +1,78 @@
+[[fh-sync-globalhandlecollision]]
+== $fh.sync.globalHandleCollision
+
+Defines a global handler function for dealing with data collisions.
+
+You can try resolve the collision in this function, or just persist the collision somewhere for later review.
+
+It can be used by multiple datasets, but will only be used if there is no handler assigned to the dataset via the link:./handleCollision.adoc[handleCollision API].
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.globalHandleCollision(function collisionHandler(dataset_id, hash, timestamp, uid, pre, post, meta_data, cb){});
+----
+
+=== Parameters
+
+==== collisionHandler
+* Description: The function that will be invoked when a collision is generated.
+* Type: Function
+* Invoked Parameters:
+** *dataset_id*
+*** Description: the id of the dataset
+*** Type: String
+** *hash*
+*** Description: the unique hash value of the collision
+*** Type: String
+** *timestamp*
+*** Description: the timestamp when the change is generated on the client. In milliseconds.
+*** Type: Number
+** *uid*
+*** Description: the unique id of the record that should be deleted
+*** Type: String
+** *pre*
+*** Description: the data before the change 
+*** Type: Object
+** *post*
+*** Description: the changed data
+*** Type: Object
+** *meta_data*
+*** Description: the meta data associated with the data. Could be null.
+*** Type: Object
+** *cb*
+*** Description: the callback function
+*** Type: Function
+
+=== Example
+
+[source,javascript]
+----
+// Typically a collision handler will write the data record to a collisions table
+// which is reviewed by a user who can manually reconcile the collisions.
+$fh.sync.globalHandleCollision(function(dataset_id, hash, timestamp, uid, pre, post, meta_data, cb) {
+  // The dataset identifier that this function was defined for
+  console.log(dataset_id);
+
+  // Unique hash value identifying the collision
+  console.log(hash);
+
+  // Date / time that update was created on client device
+  console.log(timestamp);
+
+  // Unique Identifier for row
+  console.log(uid);
+
+  // The data row the client started with
+  console.log(pre);
+
+  //The data row the client tried to write
+  console.log(post);
+
+  // sample back-end storage call
+  saveCollisionData(dataset_id, hash, timestamp, uid, pre, post);
+
+  return cb();
+});
+----

--- a/sync_cloud_api/globalHandleCreate.adoc
+++ b/sync_cloud_api/globalHandleCreate.adoc
@@ -1,0 +1,55 @@
+[[fh-sync-globalhandlecreate]]
+== $fh.sync.globalHandleCreate
+
+Defines a global handler function for creating a single row of data in the back end.
+
+It can be used by multiple datasets, but will only be used if there is no handler assigned to the dataset via the link:./handleCreate.adoc[handleCreate API].
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.globalHandleCreate(function createHandler(dataset_id, data, meta_data, cb){});
+----
+
+=== Parameters
+
+==== createHandler
+* Description: The function that will be invoked when creating a record.
+* Type: Function
+* Invoked Parameters:
+** *dataset_id*
+*** Description: the id of the dataset
+*** Type: String
+** *data*
+*** Description: the data that needs to be created
+*** Type: Object
+** *meta_data*
+*** Description: the meta data associated with the data. Could be null.
+*** Type: Object
+** *cb*
+*** Description: the callback function
+*** Type: Function
+
+=== Example
+
+[source,javascript]
+----
+$fh.sync.globalHandleCreate(function(dataset_id, data, meta_data, cb){
+  // The dataset identifier that this function was defined for
+  console.log(dataset_id);
+
+  // Row of data to create
+  console.log(data);
+
+  // Sample back-end storage call
+  var savedData = saveData(data);
+  var res = {
+    "uid": savedData.uid, // Unique Identifier for row
+    "data": savedData.data // The created data record - including any system or UID fields added during the create process
+  };
+
+  // Callback function for when the data has been created, or if theres an error
+  return cb(null, res);
+});
+----

--- a/sync_cloud_api/globalHandleDelete.adoc
+++ b/sync_cloud_api/globalHandleDelete.adoc
@@ -1,0 +1,61 @@
+[[fh-sync-globalhandledelete]]
+== $fh.sync.globalHandleDelete
+
+Defines a global handler function for deleting a single row of data from the back end.
+
+It can be used by multiple datasets, but will only be used if there is no handler assigned to the dataset via the link:./handleDelete.adoc[handleDelete API].
+
+The sync server will make sure the data can be deleted. I.e. the data to be deleted is up to date and will not cause collisions.
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.globalHandleDelete(function deleteHandler(dataset_id, uid, meta_data, cb){});
+----
+
+=== Parameters
+
+==== deleteHandler
+* Description: The function that will be invoked when deleting a record.
+* Type: Function
+* Invoked Parameters:
+** *dataset_id*
+*** Description: the id of the dataset
+*** Type: String
+** *uid*
+*** Description: the unique id of the record that should be deleted
+*** Type: String
+** *meta_data*
+*** Description: the meta data associated with the data. Could be null.
+*** Type: Object
+** *cb*
+*** Description: the callback function
+*** Type: Function
+
+=== Example
+
+[source,javascript]
+----
+$fh.sync.globalHandleDelete(function(dataset_id, uid, meta_data, cb) {
+  // The dataset identifier that this function was defined for
+  console.log(dataset_id);
+
+  // Unique Identifier for row to update
+  console.log(uid);
+
+  // Sample back-end storage call
+  var deletedData = deleteData(uid);
+
+  /* sample response
+    {
+      "userid": "1234",
+      "name": "Jane Bloggs",
+      "age": 27
+    }
+  */
+
+  // The callback into the sync service to return the deleted row of data
+  return cb(null, deletedData);
+});
+----

--- a/sync_cloud_api/globalHandleDelete.adoc
+++ b/sync_cloud_api/globalHandleDelete.adoc
@@ -1,11 +1,11 @@
 [[fh-sync-globalhandledelete]]
 == $fh.sync.globalHandleDelete
 
-Defines a global handler function for deleting a single row of data from the back end.
+Defines a global handler function for deleting a single row of data from the Dataset Backend.
 
 It can be used by multiple datasets, but will only be used if there is no handler assigned to the dataset via the link:./handleDelete.adoc[handleDelete API].
 
-The sync server will make sure the data can be deleted. I.e. the data to be deleted is up to date and will not cause collisions.
+The sync server will make sure the data can be deleted. i.e. the data to be deleted is up to date and will not cause collisions.
 
 === Usage
 

--- a/sync_cloud_api/globalHandleList.adoc
+++ b/sync_cloud_api/globalHandleList.adoc
@@ -1,7 +1,7 @@
 [[fh-sync-globalhandlelist]]
 == $fh.sync.globalHandleList
 
-Defines a global handler function for listing data from the back end.
+Defines a global handler function for listing data from the Dataset Backend.
 
 It can be used by multiple datasets, but will only be used if there is no handler assigned to the dataset via the link:./handleList.adoc[handleList API].
 

--- a/sync_cloud_api/globalHandleList.adoc
+++ b/sync_cloud_api/globalHandleList.adoc
@@ -1,0 +1,96 @@
+[[fh-sync-globalhandlelist]]
+== $fh.sync.globalHandleList
+
+Defines a global handler function for listing data from the back end.
+
+It can be used by multiple datasets, but will only be used if there is no handler assigned to the dataset via the link:./handleList.adoc[handleList API].
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.globalHandleList(function listHandler(dataset_id, query_params, meta_data, cb){});
+----
+
+=== Parameters
+
+==== listHandler
+* Description: The function that will be invoked when listing records
+* Type: Function
+* Invoked Parameters:
+** *dataset_id*
+*** Description: the id of the dataset
+*** Type: String
+** *query_params*
+*** Description: the query parameter to use as part of the list. Can be null.
+*** Type: Object
+** *meta_data*
+*** Description: the meta data associated with the data. Could be null.
+*** Type: Object
+** *cb*
+*** Description: the callback function
+*** Type: Function
+
+=== Example
+
+[source,javascript]
+----
+$fh.sync.globalHandleList(function(dataset_id, params, meta_data, cb) {
+  // The dataset identifier that this function was defined for
+  console.log(dataset_id);
+
+  // JSON object representing query parameters passed from the client.
+  // These can be used to restrict the data set returned.
+  console.log(params);
+
+  // The callback into the sync service to store the dataset
+  // cb(err, data)
+  cb(null, { // A JSON Object - representing the data
+    uid_1 : {/* data */},
+    uid_2 : {/* data */},
+    uid_3 : {/* data */}
+  });
+});
+
+// It is recommended that the handleList function converts data from the back end
+// format into a full JSON Object.
+// This is a sensible approach when reading data from relational and nonrelational
+// databases, and works well for SOAP and XML data.
+// However, it may not always be feasible - for example, when reading non structured data.
+// In these cases, the recomened approach is to create a JSON object with a single
+// key called “data” and set the value for this key to be the actual data.
+// for example, xml data
+/*
+<dataset>
+  <row>
+    <userid>123456</userid>
+    <firstname>Joe</firstname>
+    <surname>Bloggs</surname>
+    <dob>1970-01-01</dob>
+    <gender>male</gender>
+  </row>
+</dataset>
+*/
+/* json data
+{
+  "123456" : {
+    "userid" : "123456",
+    "firstname" : "Joe",
+    "surname" : "Bloggs",
+    "dob" : "1970-01-01",
+    "gender" : "male"
+  }
+}
+*/
+
+// And for non structured data:
+/*
+123456|Joe|Bloggs|1970-01-01|male
+
+{
+  "123456" : {
+    "data" : "123456|Joe|Bloggs|1970-01-01|male"
+  }
+}
+*/
+----

--- a/sync_cloud_api/globalHandleRead.adoc
+++ b/sync_cloud_api/globalHandleRead.adoc
@@ -1,0 +1,58 @@
+[[fh-sync-globalhandleread]]
+== $fh.sync.globalHandleRead
+
+Defines a global handler function for reading a single row of data from the back end.
+
+It can be used by multiple datasets, but will only be used if there is no handler assigned to the dataset via the link:./handleRead.adoc[handleRead API].
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.globalHandleRead(function readHandler(dataset_id, uid, meta_data, cb){});
+----
+
+=== Parameters
+
+==== readHandler
+* Description: The function that will be invoked when reading a record.
+* Type: Function
+* Invoked Parameters:
+** *dataset_id*
+*** Description: the id of the dataset
+*** Type: String
+** *uid*
+*** Description: the unique id of the record that should be read
+*** Type: String
+** *meta_data*
+*** Description: the meta data associated with the data. Could be null.
+*** Type: Object
+** *cb*
+*** Description: the callback function
+*** Type: Function
+
+=== Example
+
+[source,javascript]
+----
+$fh.sync.globalHandleRead(function(dataset_id, uid, meta_data, cb) {
+  // The dataset identifier that this function was defined for
+  console.log(dataset_id);
+
+  // Unique Identifier for row to read
+  console.log(uid);
+
+  // Sample back-end storage call
+  var data = readData(uid);
+  /* sample response
+    {
+      "userid": "1234",
+      "name": "Jane Bloggs",
+      "age": 27
+    }
+  */
+
+  // The callback into the sync service to return the row of data
+  return cb(null, data);
+});
+----

--- a/sync_cloud_api/globalHandleRead.adoc
+++ b/sync_cloud_api/globalHandleRead.adoc
@@ -1,7 +1,7 @@
 [[fh-sync-globalhandleread]]
 == $fh.sync.globalHandleRead
 
-Defines a global handler function for reading a single row of data from the back end.
+Defines a global handler function for reading a single row of data from the Dataset Backend.
 
 It can be used by multiple datasets, but will only be used if there is no handler assigned to the dataset via the link:./handleRead.adoc[handleRead API].
 

--- a/sync_cloud_api/globalHandleUpdate.adoc
+++ b/sync_cloud_api/globalHandleUpdate.adoc
@@ -1,11 +1,11 @@
 [[fh-sync-globalhandleupdate]]
 == $fh.sync.globalHandleUpdate
 
-Defines a global handler function for updating a single row of data on the back end.
+Defines a global handler function for updating a single row of data on the Dataset Backend.
 
 It can be used by multiple datasets, but will only be used if there is no handler assigned to the dataset via the link:./handleUpdate.adoc[handleUpdate API].
 
-The sync server will make sure the data can be updated by checking the current value is matching the value in the back end.
+The sync server will make sure the data can be updated by checking the current value is matching the value in the Dataset Backend.
 If the value doesn't match, the update operation will not be performed and a collision will be generated.
 
 === Usage

--- a/sync_cloud_api/globalHandleUpdate.adoc
+++ b/sync_cloud_api/globalHandleUpdate.adoc
@@ -1,0 +1,67 @@
+[[fh-sync-globalhandleupdate]]
+== $fh.sync.globalHandleUpdate
+
+Defines a global handler function for updating a single row of data on the back end.
+
+It can be used by multiple datasets, but will only be used if there is no handler assigned to the dataset via the link:./handleUpdate.adoc[handleUpdate API].
+
+The sync server will make sure the data can be updated by checking the current value is matching the value in the back end.
+If the value doesn't match, the update operation will not be performed and a collision will be generated.
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.globalHandleUpdate(function updateHandler(dataset_id, uid, data, meta_data, cb){});
+----
+
+=== Parameters
+
+==== updateHandler
+* Description: The function that will be invoked when updating a record.
+* Type: Function
+* Invoked Parameters:
+** *dataset_id*
+*** Description: the id of the dataset
+*** Type: String
+** *uid*
+*** Description: the unique id of the record that should be updated
+*** Type: String
+** *data*
+*** Description: the new date fields
+*** Type: Object
+** *meta_data*
+*** Description: the meta data associated with the data. Could be null.
+*** Type: Object
+** *cb*
+*** Description: the callback function
+*** Type: Function
+
+=== Example
+
+[source,javascript]
+----
+$fh.sync.globalHandleUpdate(function(dataset_id, uid, meta_data, cb) {
+  // The dataset identifier that this function was defined for
+  console.log(dataset_id);
+
+  // Unique Identifier for row to update
+  console.log(uid);
+
+  // Row of data to update
+  console.log(data);
+
+  // Sample back-end storage call
+  var updatedData = updateData(uid, data);
+  /* sample response
+    {
+      "userid": "1234",
+      "name": "Jane Bloggs",
+      "age": 27
+    }
+  */
+
+  // The callback into the sync service to return the updated row of data
+  return cb(null, updatedData);
+});
+----

--- a/sync_cloud_api/globalInterceptRequest.adoc
+++ b/sync_cloud_api/globalInterceptRequest.adoc
@@ -1,0 +1,61 @@
+[[fh-sync-globalinterceptrequest]]
+== $fh.sync.globalInterceptRequest
+
+Intercept the sync requests before it's being processed.
+Can be useful for checking client identities and validating authentication.
+
+It can be used by multiple datasets, but will only be used if there is no handler assigned to the dataset via the link:./interceptRequest.adoc[interceptRequest API].
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.globalInterceptRequest(function requestInterceptor(dataset_id, interceptorParams, cb){});
+----
+
+=== Parameters
+
+==== requestInterceptor
+* Description: The function that will be invoked when a sync request is received from clients.
+* Type: Function
+* Invoked Parameters:
+** *dataset_id*
+*** Description: the id of the dataset
+*** Type: String
+** *interceptorParams*
+*** Description: the parameters associated with the request
+*** Type: Object
+*** Supported Keys
+**** query_params
+***** Description: the query parameters associated with the request
+***** Type: Object
+**** meta_data
+***** Description: the meta data associated with the request
+***** Type: Object
+** *cb*
+*** Description: the callback function. 
++
+If it's invoked with a non-null response, the sync request will be rejected.
+*** Type: Function
+
+=== Example
+
+[source,javascript]
+----
+$fh.sync.globalInterceptRequest(function(dataset_id, interceptorParams, cb){
+
+  var query_params = interceptorParams.query_params; //the query_params specified in the client $fh.sync.manage
+  var meta_data = interceptorParams.meta_data;  //the meta_data specified in the client $fh.sync.manage
+
+  var validUser = function(qp, meta){
+    //implement user authentication and return true or false
+  };
+
+  if(validUser(query_params, meta_data)){
+    return cb(null);
+  } else {
+     // Return a non null response to cause the sync request to fail.
+    return cb({error: 'invalid user'});
+  }
+});
+----

--- a/sync_cloud_api/globalInterceptRequest.adoc
+++ b/sync_cloud_api/globalInterceptRequest.adoc
@@ -1,7 +1,7 @@
 [[fh-sync-globalinterceptrequest]]
 == $fh.sync.globalInterceptRequest
 
-Intercept the sync requests before it's being processed.
+Intercept *all* sync requests before they are passed to the sync server.
 Can be useful for checking client identities and validating authentication.
 
 It can be used by multiple datasets, but will only be used if there is no handler assigned to the dataset via the link:./interceptRequest.adoc[interceptRequest API].

--- a/sync_cloud_api/globalListCollisions.adoc
+++ b/sync_cloud_api/globalListCollisions.adoc
@@ -1,0 +1,69 @@
+[[fh-sync-globallistcollisions]]
+== $fh.sync.globalListCollisions
+
+Defines a global handler function for returning the current list of collisions.
+
+It can be used by multiple datasets, but will only be used if there is no handler assigned to the dataset via the link:./listCollisions.adoc[listCollisions API].
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.globalListCollisions(function listCollisionsHandler(dataset_id, meta_data, cb){});
+----
+
+=== Parameters
+
+==== listCollisionsHandler
+* Description: The function that will be invoked when listing collisions.
+* Type: Function
+* Invoked Parameters:
+** *dataset_id*
+*** Description: the id of the dataset
+*** Type: String
+** *meta_data*
+*** Description: the meta data associated with the data. Could be null.
+*** Type: Object
+** *cb*
+*** Description: the callback function
+*** Type: Function
+
+=== Example
+
+[source,javascript]
+----
+// This would usually be used by an administration console where a user is
+// manually reviewing & resolving collisions.
+$fh.sync.globalListCollisions(function(dataset_id, meta_data, cb) {
+  // The dataset identifier that this function was defined for
+  console.log(dataset_id);
+
+  // sample back-end storage call
+  var collisions = getCollisions(dataset_id);
+  /* sample response:
+  {
+    "collision_hash_1" : {
+      "uid": "<uid_of_data_row>",
+      "timestamp": "<timestamp_value_passed_to_handleCollision_fn>",
+      "pre": "<pre_data_record_passed_to_handleCollision_fn>",
+      "post": "<post_data_record_passed_to_handleCollision_fn>"
+    },
+    "collision_hash_2" : {
+      "uid": "<uid_of_data_row>",
+      "timestamp": "<timestamp_value_passed_to_handleCollision_fn>",
+      "pre": "<pre_data_record_passed_to_handleCollision_fn>",
+      "post": "<post_data_record_passed_to_handleCollision_fn>"
+    },
+    "collision_hash_2" : {
+      "uid": "<uid_of_data_row>",
+      "timestamp": "<timestamp_value_passed_to_handleCollision_fn>",
+      "pre": "<pre_data_record_passed_to_handleCollision_fn>",
+      "post": "<post_data_record_passed_to_handleCollision_fn>"
+    }
+  }
+  */
+
+  // The callback into the sync service to return the list of known collisions
+  return cb(null, collisions);
+});
+----

--- a/sync_cloud_api/globalRemoveCollision.adoc
+++ b/sync_cloud_api/globalRemoveCollision.adoc
@@ -1,7 +1,7 @@
 [[fh-sync-globalremovecollision]]
 == $fh.sync.globalRemoveCollision
 
-Defines a global handler function for deleting a collisions.
+Defines a global handler function for deleting a collision.
 
 It can be used by multiple datasets, but will only be used if there is no handler assigned to the dataset via the link:./removeCollision.adoc[removeCollision API].
 

--- a/sync_cloud_api/globalRemoveCollision.adoc
+++ b/sync_cloud_api/globalRemoveCollision.adoc
@@ -1,0 +1,50 @@
+[[fh-sync-globalremovecollision]]
+== $fh.sync.globalRemoveCollision
+
+Defines a global handler function for deleting a collisions.
+
+It can be used by multiple datasets, but will only be used if there is no handler assigned to the dataset via the link:./removeCollision.adoc[removeCollision API].
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.globalRemoveCollision(function removeCollisionHandler(dataset_id, collision_hash, meta_data, cb){});
+----
+
+=== Parameters
+
+==== removeCollisionHandler
+* Description: The function that will be invoked when deleting a collisions.
+* Type: Function
+* Invoked Parameters:
+** *dataset_id*
+*** Description: the id of the dataset
+*** Type: String
+** *collision_hash*
+*** Description: the unique hash of the collision
+*** Type: String
+** *meta_data*
+*** Description: the meta data associated with the data. Could be null.
+*** Type: Object
+** *cb*
+*** Description: the callback function
+*** Type: Function
+
+=== Example
+
+[source,javascript]
+----
+// This would usually be used by an administration console where a user is
+// manually reviewing & resolving collisions.
+$fh.sync.globalRemoveCollision(function(dataset_id, collision_hash, meta_data, cb) {
+  // The dataset identifier that this function was defined for
+  console.log(dataset_id);
+
+  // sample back-end storage call
+  removeCollision(collision_hash);
+
+  // The callback into the sync service to return the delete row of data
+  return cb(null);
+});
+----

--- a/sync_cloud_api/handleCollision.adoc
+++ b/sync_cloud_api/handleCollision.adoc
@@ -1,7 +1,7 @@
 [[fh-sync-handlecollision]]
 == $fh.sync.handleCollision
 
-Defines a handler function for dealing with data collisions for a dataset.
+Defines a handler function for a specific Dataset, for dealing with data collisions.
 
 You can try resolve the collision in this function, or just persist the collision somewhere for later review.
 

--- a/sync_cloud_api/handleCollision.adoc
+++ b/sync_cloud_api/handleCollision.adoc
@@ -1,0 +1,80 @@
+[[fh-sync-handlecollision]]
+== $fh.sync.handleCollision
+
+Defines a handler function for dealing with data collisions for a dataset.
+
+You can try resolve the collision in this function, or just persist the collision somewhere for later review.
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.handleCollision(dataset_id, function collisionHandler(dataset_id, hash, timestamp, uid, pre, post, meta_data, cb){});
+----
+
+=== Parameters
+
+==== dataset_id
+* Description: the id of the dataset
+* Type: String
+
+==== collisionHandler
+* Description: The function that will be invoked when a collision is generated.
+* Type: Function
+* Invoked Parameters:
+** *dataset_id*
+*** Description: the id of the dataset
+*** Type: String
+** *hash*
+*** Description: the unique hash value of the collision
+*** Type: String
+** *timestamp*
+*** Description: the timestamp when the change is generated on the client. In milliseconds.
+*** Type: Number
+** *uid*
+*** Description: the unique id of the record that should be deleted
+*** Type: String
+** *pre*
+*** Description: the data before the change 
+*** Type: Object
+** *post*
+*** Description: the changed data
+*** Type: Object
+** *meta_data*
+*** Description: the meta data associated with the data. Could be null.
+*** Type: Object
+** *cb*
+*** Description: the callback function
+*** Type: Function
+
+=== Example
+
+[source,javascript]
+----
+// Typically a collision handler will write the data record to a collisions table
+// which is reviewed by a user who can manually reconcile the collisions.
+$fh.sync.handleCollision("todo", function(dataset_id, hash, timestamp, uid, pre, post, meta_data, cb) {
+  // The dataset identifier that this function was defined for
+  console.log(dataset_id);
+
+  // Unique hash value identifying the collision
+  console.log(hash);
+
+  // Date / time that update was created on client device
+  console.log(timestamp);
+
+  // Unique Identifier for row
+  console.log(uid);
+
+  // The data row the client started with
+  console.log(pre);
+
+  //The data row the client tried to write
+  console.log(post);
+
+  // sample back-end storage call
+  saveCollisionData(dataset_id, hash, timestamp, uid, pre, post);
+
+  return cb();
+});
+----

--- a/sync_cloud_api/handleCreate.adoc
+++ b/sync_cloud_api/handleCreate.adoc
@@ -1,7 +1,7 @@
 [[fh-sync-handlecreate]]
 == $fh.sync.handleCreate
 
-Defines a handler function for creating a single row of data in the back end for a dataset.
+Defines a handler function for a specific Dataset, for creating a single row of data in the Dataset Backend.
 
 === Usage
 

--- a/sync_cloud_api/handleCreate.adoc
+++ b/sync_cloud_api/handleCreate.adoc
@@ -1,0 +1,57 @@
+[[fh-sync-handlecreate]]
+== $fh.sync.handleCreate
+
+Defines a handler function for creating a single row of data in the back end for a dataset.
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.handleCreate(dataset_id, function createHandler(dataset_id, data, meta_data, cb){});
+----
+
+=== Parameters
+
+==== dataset_id
+* Description: the id of the dataset
+* Type: String
+
+==== createHandler
+* Description: The function that will be invoked when creating a record.
+* Type: Function
+* Invoked Parameters:
+** *dataset_id*
+*** Description: the id of the dataset
+*** Type: String
+** *data*
+*** Description: the data that needs to be created
+*** Type: Object
+** *meta_data*
+*** Description: the meta data associated with the data. Could be null.
+*** Type: Object
+** *cb*
+*** Description: the callback function
+*** Type: Function
+
+=== Example
+
+[source,javascript]
+----
+$fh.sync.handleCreate("todo", function(dataset_id, data, meta_data, cb){
+  // The dataset identifier that this function was defined for
+  console.log(dataset_id);
+
+  // Row of data to create
+  console.log(data);
+
+  // Sample back-end storage call
+  var savedData = saveData(data);
+  var res = {
+    "uid": savedData.uid, // Unique Identifier for row
+    "data": savedData.data // The created data record - including any system or UID fields added during the create process
+  };
+
+  // Callback function for when the data has been created, or if theres an error
+  return cb(null, res);
+});
+----

--- a/sync_cloud_api/handleDelete.adoc
+++ b/sync_cloud_api/handleDelete.adoc
@@ -1,0 +1,63 @@
+[[fh-sync-handledelete]]
+== $fh.sync.handleDelete
+
+Defines a handler function for deleting a single row of data from the back end for a dataset.
+
+The sync server will make sure the data can be deleted. I.e. the data to be deleted is up to date and will not cause collisions.
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.handleDelete(dataset_id, function deleteHandler(dataset_id, uid, meta_data, cb){});
+----
+
+=== Parameters
+
+==== dataset_id
+* Description: the id of the dataset
+* Type: String
+
+==== deleteHandler
+* Description: The function that will be invoked when deleting a record.
+* Type: Function
+* Invoked Parameters:
+** *dataset_id*
+*** Description: the id of the dataset
+*** Type: String
+** *uid*
+*** Description: the unique id of the record that should be deleted
+*** Type: String
+** *meta_data*
+*** Description: the meta data associated with the data. Could be null.
+*** Type: Object
+** *cb*
+*** Description: the callback function
+*** Type: Function
+
+=== Example
+
+[source,javascript]
+----
+$fh.sync.handleDelete("todo", function(dataset_id, uid, meta_data, cb) {
+  // The dataset identifier that this function was defined for
+  console.log(dataset_id);
+
+  // Unique Identifier for row to update
+  console.log(uid);
+
+  // Sample back-end storage call
+  var deletedData = deleteData(uid);
+
+  /* sample response
+    {
+      "userid": "1234",
+      "name": "Jane Bloggs",
+      "age": 27
+    }
+  */
+
+  // The callback into the sync service to return the deleted row of data
+  return cb(null, deletedData);
+});
+----

--- a/sync_cloud_api/handleDelete.adoc
+++ b/sync_cloud_api/handleDelete.adoc
@@ -1,7 +1,7 @@
 [[fh-sync-handledelete]]
 == $fh.sync.handleDelete
 
-Defines a handler function for deleting a single row of data from the back end for a dataset.
+Defines a handler function for a specific Dataset, for deleting a single row of data from the Dataset Backend.
 
 The sync server will make sure the data can be deleted. I.e. the data to be deleted is up to date and will not cause collisions.
 

--- a/sync_cloud_api/handleList.adoc
+++ b/sync_cloud_api/handleList.adoc
@@ -1,7 +1,7 @@
 [[fh-sync-handlelist]]
 == $fh.sync.handleList
 
-Defines a handler function for listing data from the back end for a dataset.
+Defines a handler function for a specific Dataset, for listing data from the Dataset Backend.
 
 === Usage
 

--- a/sync_cloud_api/handleList.adoc
+++ b/sync_cloud_api/handleList.adoc
@@ -1,0 +1,98 @@
+[[fh-sync-handlelist]]
+== $fh.sync.handleList
+
+Defines a handler function for listing data from the back end for a dataset.
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.handleList(dataset_id, function listHandler(dataset_id, query_params, meta_data, cb){});
+----
+
+=== Parameters
+
+==== dataset_id
+* Description: the id of the dataset
+* Type: String
+
+==== listHandler
+* Description: The function that will be invoked when listing records
+* Type: Function
+* Invoked Parameters:
+** *dataset_id*
+*** Description: the id of the dataset
+*** Type: String
+** *query_params*
+*** Description: the query parameter to use as part of the list. Can be null.
+*** Type: Object
+** *meta_data*
+*** Description: the meta data associated with the data. Could be null.
+*** Type: Object
+** *cb*
+*** Description: the callback function
+*** Type: Function
+
+=== Example
+
+[source,javascript]
+----
+$fh.sync.handleList("todo", function(dataset_id, params, meta_data, cb) {
+  // The dataset identifier that this function was defined for
+  console.log(dataset_id);
+
+  // JSON object representing query parameters passed from the client.
+  // These can be used to restrict the data set returned.
+  console.log(params);
+
+  // The callback into the sync service to store the dataset
+  // cb(err, data)
+  cb(null, { // A JSON Object - representing the data
+    uid_1 : {/* data */},
+    uid_2 : {/* data */},
+    uid_3 : {/* data */}
+  });
+});
+
+// It is recommended that the handleList function converts data from the back end
+// format into a full JSON Object.
+// This is a sensible approach when reading data from relational and nonrelational
+// databases, and works well for SOAP and XML data.
+// However, it may not always be feasible - for example, when reading non structured data.
+// In these cases, the recomened approach is to create a JSON object with a single
+// key called “data” and set the value for this key to be the actual data.
+// for example, xml data
+/*
+<dataset>
+  <row>
+    <userid>123456</userid>
+    <firstname>Joe</firstname>
+    <surname>Bloggs</surname>
+    <dob>1970-01-01</dob>
+    <gender>male</gender>
+  </row>
+</dataset>
+*/
+/* json data
+{
+  "123456" : {
+    "userid" : "123456",
+    "firstname" : "Joe",
+    "surname" : "Bloggs",
+    "dob" : "1970-01-01",
+    "gender" : "male"
+  }
+}
+*/
+
+// And for non structured data:
+/*
+123456|Joe|Bloggs|1970-01-01|male
+
+{
+  "123456" : {
+    "data" : "123456|Joe|Bloggs|1970-01-01|male"
+  }
+}
+*/
+----

--- a/sync_cloud_api/handleRead.adoc
+++ b/sync_cloud_api/handleRead.adoc
@@ -1,0 +1,60 @@
+[[fh-sync-handleread]]
+== $fh.sync.handleRead
+
+Defines a handler function for reading a single row of data from the back end for a dataset.
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.handleRead(dataset_id, function readHandler(dataset_id, uid, meta_data, cb){});
+----
+
+=== Parameters
+
+==== dataset_id
+* Description: the id of the dataset
+* Type: String
+
+==== readHandler
+* Description: The function that will be invoked when reading a record.
+* Type: Function
+* Invoked Parameters:
+** *dataset_id*
+*** Description: the id of the dataset
+*** Type: String
+** *uid*
+*** Description: the unique id of the record that should be read
+*** Type: String
+** *meta_data*
+*** Description: the meta data associated with the data. Could be null.
+*** Type: Object
+** *cb*
+*** Description: the callback function
+*** Type: Function
+
+=== Example
+
+[source,javascript]
+----
+$fh.sync.handleRead("todo", function(dataset_id, uid, meta_data, cb) {
+  // The dataset identifier that this function was defined for
+  console.log(dataset_id);
+
+  // Unique Identifier for row to read
+  console.log(uid);
+
+  // Sample back-end storage call
+  var data = readData(uid);
+  /* sample response
+    {
+      "userid": "1234",
+      "name": "Jane Bloggs",
+      "age": 27
+    }
+  */
+
+  // The callback into the sync service to return the row of data
+  return cb(null, data);
+});
+----

--- a/sync_cloud_api/handleRead.adoc
+++ b/sync_cloud_api/handleRead.adoc
@@ -1,7 +1,7 @@
 [[fh-sync-handleread]]
 == $fh.sync.handleRead
 
-Defines a handler function for reading a single row of data from the back end for a dataset.
+Defines a handler function for a specific Dataset, for reading a single row of data from the Dataset Backend.
 
 === Usage
 

--- a/sync_cloud_api/handleUpdate.adoc
+++ b/sync_cloud_api/handleUpdate.adoc
@@ -1,7 +1,7 @@
 [[fh-sync-handleupdate]]
 == $fh.sync.handleUpdate
 
-Defines a handler function for updating a single row of data on the back end for a dataset.
+Defines a handler function for a specific Dataset, for updating a single row of data on the Dataset Backend.
 
 The sync server will make sure the data can be updated by checking the current value is matching the value in the back end.
 If the value doesn't match, the update operation will not be performed and a collision will be generated.

--- a/sync_cloud_api/handleUpdate.adoc
+++ b/sync_cloud_api/handleUpdate.adoc
@@ -1,0 +1,69 @@
+[[fh-sync-handleupdate]]
+== $fh.sync.handleUpdate
+
+Defines a handler function for updating a single row of data on the back end for a dataset.
+
+The sync server will make sure the data can be updated by checking the current value is matching the value in the back end.
+If the value doesn't match, the update operation will not be performed and a collision will be generated.
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.handleUpdate(dataset_id, function updateHandler(dataset_id, uid, data, meta_data, cb){});
+----
+
+=== Parameters
+
+==== dataset_id
+* Description: the id of the dataset
+* Type: String
+
+==== updateHandler
+* Description: The function that will be invoked when updating a record.
+* Type: Function
+* Invoked Parameters:
+** *dataset_id*
+*** Description: the id of the dataset
+*** Type: String
+** *uid*
+*** Description: the unique id of the record that should be updated
+*** Type: String
+** *data*
+*** Description: the new date fields
+*** Type: Object
+** *meta_data*
+*** Description: the meta data associated with the data. Could be null.
+*** Type: Object
+** *cb*
+*** Description: the callback function
+*** Type: Function
+
+=== Example
+
+[source,javascript]
+----
+$fh.sync.handleUpdate("todo", function(dataset_id, uid, meta_data, cb) {
+  // The dataset identifier that this function was defined for
+  console.log(dataset_id);
+
+  // Unique Identifier for row to update
+  console.log(uid);
+
+  // Row of data to update
+  console.log(data);
+
+  // Sample back-end storage call
+  var updatedData = updateData(uid, data);
+  /* sample response
+    {
+      "userid": "1234",
+      "name": "Jane Bloggs",
+      "age": 27
+    }
+  */
+
+  // The callback into the sync service to return the updated row of data
+  return cb(null, updatedData);
+});
+----

--- a/sync_cloud_api/init.adoc
+++ b/sync_cloud_api/init.adoc
@@ -1,11 +1,11 @@
 [[fh-sync-init]]
 == $fh.sync.init
 
-Set the sync options for the given dataset and start the sync process.
+Set the sync options for the given Dataset and start the sync process.
 
-Can also be used to restart the sync process on a dataset after it's stopped.
+Can also be used to restart the sync process on a Dataset after it's stopped.
 
-This function call is optional, you don't have to call it if the default option works.
+This function call is optional. However, you may want to call to override options for a specific Dataset.
 
 === Usage
 
@@ -23,24 +23,24 @@ $fh.sync.init(dataset_id, options, callback)
 
 ==== options
 
-* Description: The sync options for the dataset. If not provided, defaults will be used.
+* Description: The sync options for the Dataset. If not provided, defaults will be used.
 * Type: Object
 * Supported Keys:
 ** *syncFrequency*
-*** Description: Specify how long the sync server should wait between each operation which will sync local datasets with the Backend Database. In seconds.
+*** Description: Specify how long the sync server should wait between each operation which will sync local Datasets with the Backend Database. In seconds.
 +
 To decide the right value for this option, please check link:./sync_performance_scaling_guide.adoc[Sync Performance and Scaling Guide]
 *** Type: Number
 *** Default: 30
 
 ** *clientSyncTimeout*
-*** Description: Specify the period of time for which if a dataset client hasn't been accessed by any user, the dataset client will be marked as "inactive". In seconds.
+*** Description: Specify the period of time for which if a Dataset client hasn't been accessed by any user, the Dataset client will be marked as "inactive". In seconds.
 +
-If a dataset client is marked as "inactive", the sync server will stop syncing the data of the dataset client with the backend.
+If a Dataset client is marked as "inactive", the sync server will stop syncing the data of the Dataset client with the backend.
 +
-This means if a user access an "inacitve" dataset client again later on, the user may get stalled data until the next sync operation is completed.
+This means if a user access an "inacitve" Dataset client again later on, the user may get stalled data until the next sync operation is completed.
 +
-To avoid that, you can set it to a relatively long value so that a dataset client is only marked as "inactive" when no user has accessed it for a long period.
+To avoid that, you can set it to a relatively long value so that a Dataset client is only marked as "inactive" when no user has accessed it for a long period.
 
 *** Type: Number
 *** Default: 3600 (1 hour)

--- a/sync_cloud_api/init.adoc
+++ b/sync_cloud_api/init.adoc
@@ -1,0 +1,74 @@
+[[fh-sync-init]]
+== $fh.sync.init
+
+Set the sync options for the given dataset and start the sync process.
+
+Can also be used to restart the sync process on a dataset after it's stopped.
+
+This function call is optional, you don't have to call it if the default option works.
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.init(dataset_id, options, callback)
+----
+
+=== Parameters
+
+==== dataset_id
+
+* Description: The id of the dataset that needs to be synced.
+* Type: String
+
+==== options
+
+* Description: The sync options for the dataset. If not provided, defaults will be used.
+* Type: Object
+* Supported Keys:
+** *syncFrequency*
+*** Description: Specify how long the sync server should wait between each operation which will sync local datasets with the Backend Database. In seconds.
++
+To decide the right value for this option, please check link:./sync_performance_scaling_guide.adoc[Sync Performance and Scaling Guide]
+*** Type: Number
+*** Default: 30
+
+** *clientSyncTimeout*
+*** Description: Specify the period of time for which if a dataset client hasn't been accessed by any user, the dataset client will be marked as "inactive". In seconds.
++
+If a dataset client is marked as "inactive", the sync server will stop syncing the data of the dataset client with the backend.
++
+This means if a user access an "inacitve" dataset client again later on, the user may get stalled data until the next sync operation is completed.
++
+To avoid that, you can set it to a relatively long value so that a dataset client is only marked as "inactive" when no user has accessed it for a long period.
+
+*** Type: Number
+*** Default: 3600 (1 hour)
+
+** *backendListTimeout*
+*** Description: Specify the timeout value the sync server should wait for the sync operation with the Backend Database to complete. In seconds. 
+*** Type: Number
+*** Default: 300
+
+==== callback
+
+* Description: The callback function to be invoked when init is finished.
+* Type: Function
+
+=== Example
+
+[source,javascript]
+----
+var datasetId = "todolist";
+var syncOptions = {
+  syncFrequency: 10,
+  clientSyncTimeout: 24*60*60
+};
+$fh.sync.init(datasetId, syncOptions, function(err){
+  if (err) {
+    console.error('sync init failed due to error', err);
+  } else {
+    console.log('sync init finished successfully');
+  }
+});
+----

--- a/sync_cloud_api/interceptRequest.adoc
+++ b/sync_cloud_api/interceptRequest.adoc
@@ -1,7 +1,7 @@
 [[fh-sync-interceptrequest]]
 == $fh.sync.interceptRequest
 
-Intercept the sync requests for a dataset before it's being processed.
+Intercept the sync requests for a specific Dataset before it's being processed.
 Can be useful for checking client identities and validating authentication.
 
 === Usage
@@ -14,7 +14,7 @@ $fh.sync.interceptRequest(dataset_id, function requestInterceptor(dataset_id, in
 === Parameters
 
 ==== dataset_id
-* Description: the id of the dataset
+* Description: the id of the Dataset
 * Type: String
 
 ==== requestInterceptor
@@ -22,7 +22,7 @@ $fh.sync.interceptRequest(dataset_id, function requestInterceptor(dataset_id, in
 * Type: Function
 * Invoked Parameters:
 ** *dataset_id*
-*** Description: the id of the dataset
+*** Description: the id of the Dataset
 *** Type: String
 ** *interceptorParams*
 *** Description: the parameters associated with the request

--- a/sync_cloud_api/interceptRequest.adoc
+++ b/sync_cloud_api/interceptRequest.adoc
@@ -1,0 +1,63 @@
+[[fh-sync-interceptrequest]]
+== $fh.sync.interceptRequest
+
+Intercept the sync requests for a dataset before it's being processed.
+Can be useful for checking client identities and validating authentication.
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.interceptRequest(dataset_id, function requestInterceptor(dataset_id, interceptorParams, cb){});
+----
+
+=== Parameters
+
+==== dataset_id
+* Description: the id of the dataset
+* Type: String
+
+==== requestInterceptor
+* Description: The function that will be invoked when a sync request is received from clients.
+* Type: Function
+* Invoked Parameters:
+** *dataset_id*
+*** Description: the id of the dataset
+*** Type: String
+** *interceptorParams*
+*** Description: the parameters associated with the request
+*** Type: Object
+*** Supported Keys
+**** query_params
+***** Description: the query parameters associated with the request
+***** Type: Object
+**** meta_data
+***** Description: the meta data associated with the request
+***** Type: Object
+** *cb*
+*** Description: the callback function. 
++
+If it's invoked with a non-null response, the sync request will be rejected.
+*** Type: Function
+
+=== Example
+
+[source,javascript]
+----
+$fh.sync.interceptRequest("todo", function(dataset_id, interceptorParams, cb){
+
+  var query_params = interceptorParams.query_params; //the query_params specified in the client $fh.sync.manage
+  var meta_data = interceptorParams.meta_data;  //the meta_data specified in the client $fh.sync.manage
+
+  var validUser = function(qp, meta){
+    //implement user authentication and return true or false
+  };
+
+  if(validUser(query_params, meta_data)){
+    return cb(null);
+  } else {
+     // Return a non null response to cause the sync request to fail.
+    return cb({error: 'invalid user'});
+  }
+});
+----

--- a/sync_cloud_api/invoke.adoc
+++ b/sync_cloud_api/invoke.adoc
@@ -1,0 +1,56 @@
+[[fh-sync-invoke]]
+== $fh.sync.invoke
+
+Invoke certain functions of the sync server.
+
+This is useful if you need to invoke those functions programmatically.
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.invoke(dataset_id, params, callback)
+----
+
+=== Parameters
+
+==== dataset_id
+* Description: the id of the dataset
+* Type: String
+
+==== *params*
+* Description: Specify the target function name, and also it will be passed to the target function.
+* Type: Object
+* Supported Keys:
+** *fn*
+*** Description: specify the name of the function to invoke. Supported functions including:
+**** _sync_
+**** _syncRecords_
+**** _listCollisions_
+**** _removeCollision_
+*** Type: String
+** Other fields will be vary depending on the target function. Please check the source code for the required fields.
+
+=== Example
+
+[source,javascript]
+----
+var datasetId = "todo";
+var syncRecordsParams = {
+  fn: 'syncRecords',
+  dataset_id: datasetId,
+  query_params: {},
+  clientRecs: {},
+  __fh: {
+    cuid: 'testdeviceid'
+  }
+};
+
+$fh.sync.invoke(datasetId, syncRecordsParams, function(err, syncData) {
+  if (err) {
+    console.error('Failed to call syncRecords due to error', err);
+  } else {
+    console.log('Got sync data', syncData);
+  }
+});
+----

--- a/sync_cloud_api/invoke.adoc
+++ b/sync_cloud_api/invoke.adoc
@@ -1,9 +1,12 @@
 [[fh-sync-invoke]]
 == $fh.sync.invoke
 
-Invoke certain functions of the sync server.
+Invoke internal sync functions of the sync server.
 
-This is useful if you need to invoke those functions programmatically.
+This is useful if you need to invoke these functions programmatically.
+However, it is unlikely these will be needed under normal operation.
+This function is whats called by Sync clients.
+Hence the _params_ object is the same as the request body from Sync clients.
 
 === Usage
 

--- a/sync_cloud_api/listCollisions.adoc
+++ b/sync_cloud_api/listCollisions.adoc
@@ -1,7 +1,7 @@
 [[fh-sync-listcollisions]]
 == $fh.sync.listCollisions
 
-Defines a handler function for returning the current list of collisions for a dataset.
+Defines a handler function for returning the current list of collisions for a Dataset.
 
 === Usage
 

--- a/sync_cloud_api/listCollisions.adoc
+++ b/sync_cloud_api/listCollisions.adoc
@@ -1,0 +1,71 @@
+[[fh-sync-listcollisions]]
+== $fh.sync.listCollisions
+
+Defines a handler function for returning the current list of collisions for a dataset.
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.listCollisions(dataset_id, function listCollisionsHandler(dataset_id, meta_data, cb){});
+----
+
+=== Parameters
+
+==== dataset_id
+* Description: the id of the dataset
+* Type: String
+
+==== listCollisionsHandler
+* Description: The function that will be invoked when listing collisions.
+* Type: Function
+* Invoked Parameters:
+** *dataset_id*
+*** Description: the id of the dataset
+*** Type: String
+** *meta_data*
+*** Description: the meta data associated with the data. Could be null.
+*** Type: Object
+** *cb*
+*** Description: the callback function
+*** Type: Function
+
+=== Example
+
+[source,javascript]
+----
+// This would usually be used by an administration console where a user is
+// manually reviewing & resolving collisions.
+$fh.sync.listCollisions("todo", function(dataset_id, meta_data, cb) {
+  // The dataset identifier that this function was defined for
+  console.log(dataset_id);
+
+  // sample back-end storage call
+  var collisions = getCollisions(dataset_id);
+  /* sample response:
+  {
+    "collision_hash_1" : {
+      "uid": "<uid_of_data_row>",
+      "timestamp": "<timestamp_value_passed_to_handleCollision_fn>",
+      "pre": "<pre_data_record_passed_to_handleCollision_fn>",
+      "post": "<post_data_record_passed_to_handleCollision_fn>"
+    },
+    "collision_hash_2" : {
+      "uid": "<uid_of_data_row>",
+      "timestamp": "<timestamp_value_passed_to_handleCollision_fn>",
+      "pre": "<pre_data_record_passed_to_handleCollision_fn>",
+      "post": "<post_data_record_passed_to_handleCollision_fn>"
+    },
+    "collision_hash_2" : {
+      "uid": "<uid_of_data_row>",
+      "timestamp": "<timestamp_value_passed_to_handleCollision_fn>",
+      "pre": "<pre_data_record_passed_to_handleCollision_fn>",
+      "post": "<post_data_record_passed_to_handleCollision_fn>"
+    }
+  }
+  */
+
+  // The callback into the sync service to return the list of known collisions
+  return cb(null, collisions);
+});
+----

--- a/sync_cloud_api/removeCollision.adoc
+++ b/sync_cloud_api/removeCollision.adoc
@@ -1,7 +1,7 @@
 [[fh-sync-removecollisions]]
 == $fh.sync.removeCollisions
 
-Defines a handler function for deleting a collisions for a dataset.
+Defines a handler function for deleting a collision for a Dataset.
 
 === Usage
 

--- a/sync_cloud_api/removeCollision.adoc
+++ b/sync_cloud_api/removeCollision.adoc
@@ -1,0 +1,52 @@
+[[fh-sync-removecollisions]]
+== $fh.sync.removeCollisions
+
+Defines a handler function for deleting a collisions for a dataset.
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.removeCollisions(dataset_id, function removeCollisionHandler(dataset_id, collision_hash, meta_data, cb){});
+----
+
+=== Parameters
+
+==== dataset_id
+* Description: the id of the dataset
+* Type: String
+
+==== removeCollisionHandler
+* Description: The function that will be invoked when deleting a collisions.
+* Type: Function
+* Invoked Parameters:
+** *dataset_id*
+*** Description: the id of the dataset
+*** Type: String
+** *collision_hash*
+*** Description: the unique hash of the collision
+*** Type: String
+** *meta_data*
+*** Description: the meta data associated with the data. Could be null.
+*** Type: Object
+** *cb*
+*** Description: the callback function
+*** Type: Function
+
+=== Example
+
+[source,javascript]
+----
+// This would usually be used by an administration console where a user is
+// manually reviewing & resolving collisions.
+$fh.sync.removeCollisions("todo", function(dataset_id, collision_hash, meta_data, cb) {
+  // The dataset identifier that this function was defined for
+  console.log(dataset_id);
+
+  // sample back-end storage call
+  removeCollision(collision_hash);
+
+  // The callback into the sync service to return the delete row of data
+  return cb(null);
+});
+----

--- a/sync_cloud_api/setConfig.adoc
+++ b/sync_cloud_api/setConfig.adoc
@@ -4,6 +4,8 @@
 Configure the sync server. 
 
 It should be called when the sync server is ready, and before initialising any of the datasets.
+Initialisation of a Dataset typically happen when the first Sync client connects, unless you have explicit calls to `sync.init`.
+Either way, a reasonable location to call `setConfig` is when the `sync:ready` event triggers.
 
 === Usage
 
@@ -21,7 +23,7 @@ $fh.sync.setConfig(options)
 * Supported Keys
 
 ** *pendingWorkerInterval*
-*** Description: Set the interval value for the pending workers. In milliseconds.
+*** Description: Set the interval value for the pending workers, in milliseconds.
 For more details about the worker interval, please see link:./sync_configuration_guide.adoc[Sync Configuration Guide].
 *** Type: Number
 *** Default: 1
@@ -38,7 +40,7 @@ Valid values are `exp` (exponential) and `fib` (fibonacci).
 Set it to anything else will disable it.
 **** max
 +
-The max delay time for the backoff strategy. In milliseconds.
+The max delay time for the backoff strategy, in milliseconds.
 
 ** *pendingWorkerConcurrency*
 *** Description: Set the number of concurrent pending workers.
@@ -47,7 +49,7 @@ Set it to 0 will disable the pending workers.
 *** Default: 1
 
 ** *ackWorkerInterval*
-*** Description: Set the interval value for the ack workers. In milliseconds.
+*** Description: Set the interval value for the ack workers, in milliseconds.
 For more details about the worker interval, please see link:./sync_configuration_guide.adoc[Sync Configuration Guide].
 *** Type: Number
 *** Default: 1
@@ -64,7 +66,7 @@ Valid values are `exp` (exponential) and `fib` (fibonacci).
 Set it to anything else will disable it.
 **** max
 +
-The max delay time for the backoff strategy. In milliseconds.
+The max delay time for the backoff strategy, in milliseconds.
 
 ** *ackWorkerConcurrency*
 *** Description: Set the number of concurrent ack workers.
@@ -73,7 +75,7 @@ Set it to 0 will disable the ack workers.
 *** Default: 1
 
 ** *syncWorkerInterval*
-*** Description: Set the interval value for the sync workers. In milliseconds.
+*** Description: Set the interval value for the sync workers, in milliseconds.
 For more details about the worker interval, please see link:./sync_configuration_guide.adoc[Sync Configuration Guide].
 *** Type: Number
 *** Default: 100
@@ -90,7 +92,7 @@ Valid values are `exp` (exponential) and `fib` (fibonacci).
 Set it to anything else will disable it.
 **** max
 +
-The max delay time for the backoff strategy. In milliseconds.
+The max delay time for the backoff strategy, in milliseconds.
 
 ** *syncWorkerConcurrency*
 *** Description: Set the number of concurrent sync workers.
@@ -113,7 +115,7 @@ The stats data will be saved in Redis and will only have minimum performance ove
 *** Default: 1000
 
 ** *collectStatsInterval*
-*** Description: Determine how often the stats should be collected. In milliseconds.
+*** Description: Determine how often the stats should be collected, in milliseconds.
 *** Type: Number
 *** Default: 5000
 
@@ -141,7 +143,7 @@ This option will decide what messages should be kept in database.
 Other supported units including: _s_ (second), _m_ (minute), _h_ (hour), _d_ (day), _w_ (week), _y_ (year)
 
 ** *queuePruneFrequency*
-*** Description: Decide how often the queues should be checked to remove some of the acknowledged messages. In milliseconds.
+*** Description: Decide how often the queues should be checked to remove some of the acknowledged messages, in milliseconds.
 *** Type: Number
 *** Default: 3600000 (1 hour)
 
@@ -155,7 +157,7 @@ It is an experiment feature. It may cause delay for changes to be visible to all
 *** Default: false
 
 ** *schedulerInterval*
-*** Description: set the interval for the sync scheduler. In milliseconds.
+*** Description: set the interval for the sync scheduler, in milliseconds.
 +
 Should not need to be changed in most cases.
 *** Type: Number

--- a/sync_cloud_api/setConfig.adoc
+++ b/sync_cloud_api/setConfig.adoc
@@ -1,0 +1,211 @@
+[[fh-sync-setConfig]]
+== $fh.sync.setConfig
+
+Configure the sync server. 
+
+It should be called when the sync server is ready, and before initialising any of the datasets.
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.setConfig(options)
+----
+
+=== Prameters
+
+==== options
+
+* Description: Configuration options for the sync server
+* Type: Object
+* Supported Keys
+
+** *pendingWorkerInterval*
+*** Description: Set the interval value for the pending workers. In milliseconds.
+For more details about the worker interval, please see link:./sync_configuration_guide.adoc[Sync Configuration Guide].
+*** Type: Number
+*** Default: 1
+
+** *pendingWorkerBackoff*
+*** Description: Specify the backoff strategy for the pending workers.
+For more details about the worker backoff, please see link:./sync_configuration_guide.adoc[Sync Configuration Guide].
+*** Type: Object
+*** Default: _{strategy: 'exp', max: 60000}_
+**** strategy
++
+Define the backoff strategy.
+Valid values are `exp` (exponential) and `fib` (fibonacci).
+Set it to anything else will disable it.
+**** max
++
+The max delay time for the backoff strategy. In milliseconds.
+
+** *pendingWorkerConcurrency*
+*** Description: Set the number of concurrent pending workers.
+Set it to 0 will disable the pending workers.
+*** Type: Number
+*** Default: 1
+
+** *ackWorkerInterval*
+*** Description: Set the interval value for the ack workers. In milliseconds.
+For more details about the worker interval, please see link:./sync_configuration_guide.adoc[Sync Configuration Guide].
+*** Type: Number
+*** Default: 1
+
+** *ackWorkerBackoff*
+*** Description: Specify the backoff strategy for the ack workers.
+For more details about the worker backoff, please see link:./sync_configuration_guide.adoc[Sync Configuration Guide].
+*** Type: Object
+*** Default: _{strategy: 'exp', max: 60000}_
+**** strategy
++
+Define the backoff strategy.
+Valid values are `exp` (exponential) and `fib` (fibonacci).
+Set it to anything else will disable it.
+**** max
++
+The max delay time for the backoff strategy. In milliseconds.
+
+** *ackWorkerConcurrency*
+*** Description: Set the number of concurrent ack workers.
+Set it to 0 will disable the ack workers.
+*** Type: Number
+*** Default: 1
+
+** *syncWorkerInterval*
+*** Description: Set the interval value for the sync workers. In milliseconds.
+For more details about the worker interval, please see link:./sync_configuration_guide.adoc[Sync Configuration Guide].
+*** Type: Number
+*** Default: 100
+
+** *syncWorkerBackoff*
+*** Description: Specify the backoff strategy for the sync workers.
+For more details about the worker backoff, please see link:./sync_configuration_guide.adoc[Sync Configuration Guide].
+*** Type: Object
+*** Default: _{strategy: 'none'}_
+**** strategy
++
+Define the backoff strategy.
+Valid values are `exp` (exponential) and `fib` (fibonacci).
+Set it to anything else will disable it.
+**** max
++
+The max delay time for the backoff strategy. In milliseconds.
+
+** *syncWorkerConcurrency*
+*** Description: Set the number of concurrent sync workers.
+Set it to 0 will disable the sync workers.
+*** Type: Number
+*** Default: 1
+
+** *collectStats*
+*** Description: Determine if the sync server should collect performance stats data.
++
+By default, the sync server will collect some performance stats data, for example, db operation timing, API timing, queue size etc.
++
+The stats data will be saved in Redis and will only have minimum performance overhead.
+*** Type: Boolean
+*** Default: true
+
+** *statsRecordsToKeep*
+*** Description: Determine how many stats data points to save for each metric series in Redis.
+*** Type: Number
+*** Default: 1000
+
+** *collectStatsInterval*
+*** Description: Determine how often the stats should be collected. In milliseconds.
+*** Type: Number
+*** Default: 5000
+
+** *metricsInfluxdbHost*
+*** Description: Specify the InfluxDB host to which the sync server will send stats data.
+*** Type: String
+*** Default: null
+
+** *metricsInfluxdbPort*
+*** Description: Specify the InfluxDB port. It needs to be a UDP port.
+*** Type: Number
+*** Default: null
+
+** *queueMessagesToKeep*
+*** Description: The queue messages are saved in the database.
+When a message is acknowledged, it will not be removed from database immediately for debug purpose.
++
+A recurring job will decide what messages should be kept and remove the rest.
++
+This option will decide what messages should be kept in database.
+*** Type: Object
+*** Default: _{time: '24h'}_
+**** time
++
+Other supported units including: _s_ (second), _m_ (minute), _h_ (hour), _d_ (day), _w_ (week), _y_ (year)
+
+** *queuePruneFrequency*
+*** Description: Decide how often the queues should be checked to remove some of the acknowledged messages. In milliseconds.
+*** Type: Number
+*** Default: 3600000 (1 hour)
+
+** *useCache*
+*** Description: Specify if Redis should be used to cache the records of a Dataset Client.
++
+When enabled, it should reduce the number of requests on the database, and reduce the time of the `syncRecords` API call.
++
+It is an experiment feature. It may cause delay for changes to be visible to all clients.
+*** Type: Boolean
+*** Default: false
+
+** *schedulerInterval*
+*** Description: set the interval for the sync scheduler. In milliseconds.
++
+Should not need to be changed in most cases.
+*** Type: Number
+*** Default: 500
+
+** *schedulerLockName*
+*** Description: Only 1 sync scheduler can run at any given time.
+A lock is used to make sure of that.
+This field will determine the name of the lock.
++
+Should not need to be changed in most cases.
+*** Type: String
+*** Default: _locks:sync:SyncScheduler_
+
+** *schedulerLockMaxTime*
+*** Description: Only 1 sync scheduler can run at any given time.
+A lock is used to make sure of that.
+This field will determine the maximum time the sync scheduler can hold the lock for.
+This is to prevent the sync scheduler from holding the lock forever (e.g. the process crashes).
++
+Should not need to be changed in most cases.
+*** Type: Number
+*** Default: 20000
+
+** *datasetClientUpdateConcurrency*
+*** Description: When there are a lot concurrent sync requests to the sync server, a lot of update operations to the Dataset Clients will be generated.
+To avoid overloading the database, those operations are queued and then performed with the concurrency of this option.
++
+Should not need to be changed in most cases.
+*** Type: Number
+*** Default: 10
+
+=== Example
+
+[source,javascript]
+----
+$fh.events.on('sync:ready', function(){
+  var pendingWorkerInterval = process.env.PENDING_WORKER_INTERVAL || 500;
+  var syncWorkerInterval = process.env.SYNC_WORKER_INTERVAL || 500;
+  var ackWorkerInterval = process.env.ACK_WORKER_INTERVAL || 500;
+  var useCache = process.env.USE_CACHE === 'true';
+  var syncConfig = { 
+    pendingWorkerInterval: parseInt(pendingWorkerInterval),
+    ackWorkerInterval: parseInt(ackWorkerInterval),
+    syncWorkerInterval: parseInt(syncWorkerInterval),
+    collectStatsInterval: 4000, 
+    metricsInfluxdbHost: process.env.METRICS_HOST,
+    metricsInfluxdbPort: parseInt(process.env.METRICS_PORT),
+    useCache: useCache
+  };
+  $fh.sync.setConfig(syncConfig);
+});
+----

--- a/sync_cloud_api/setGlobalHashFn.adoc
+++ b/sync_cloud_api/setGlobalHashFn.adoc
@@ -1,7 +1,7 @@
 [[fh-sync-setglobalhashfn]]
 == $fh.sync.setGlobalHashFn
 
-Define a function that will generate the global hash of a dataset.
+Define a function that will calculate the global hash of a dataset.
 The global hash will be used to determine if a dataset has changed or not.
 
 === Usage

--- a/sync_cloud_api/setGlobalHashFn.adoc
+++ b/sync_cloud_api/setGlobalHashFn.adoc
@@ -1,0 +1,39 @@
+[[fh-sync-setglobalhashfn]]
+== $fh.sync.setGlobalHashFn
+
+Define a function that will generate the global hash of a dataset.
+The global hash will be used to determine if a dataset has changed or not.
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.setGlobalHashFn(dataset_id, function generateHash(dataRecordHashes){});
+----
+
+=== Parameters
+
+==== dataset_id
+* Description: the id of the dataset
+* Type: String
+
+==== generateHash
+* Description: The function that will be used to generate the hash of a dataset.
+* Type: Function
+* Invoked Parameters:
+** *dataRecordHashes*
+*** Description: an array of all the hashes of all the records in the dataset.
+*** Type: Array
+
+=== Returns
+
+The global hash value of the dataset.
+
+=== Example
+
+[source,javascript]
+----
+$fh.sync.setGlobalHashFn("todo", function(dataRecordHashes){
+  return dataRecordHashes.join('');
+});
+----

--- a/sync_cloud_api/setRecordHashFn.adoc
+++ b/sync_cloud_api/setRecordHashFn.adoc
@@ -5,8 +5,7 @@ Define a function that will generate the hash value of a single record.
 This hash value will be used to determine if a record has changed or not.
 
 A default implementation is provided but because it knows nothing about the data, the generation process is relatively complicated.
-It could be slow if the each data record has a relatively complex structure.
-But it may be not necessary if the record already have certain fields that can determine if the record is changed, like version, timestamp etc.
+It could be slow if each data record has a relatively complex structure, and the process could be avoided if the record already have certain fields that will indicate if the record is changed, like version, timestamp etc.
 
 This function will allow you to override the default implementation.
 

--- a/sync_cloud_api/setRecordHashFn.adoc
+++ b/sync_cloud_api/setRecordHashFn.adoc
@@ -2,10 +2,13 @@
 == $fh.sync.setRecordHashFn
 
 Define a function that will generate the hash value of a single record.
-This hash value will be used to determine if a record has changed or not.
+A record hash is used when comparing a cached record with the latest from the Dataset Backend.
 
-A default implementation is provided but because it knows nothing about the data, the generation process is relatively complicated.
-It could be slow if each data record has a relatively complex structure, and the process could be avoided if the record already have certain fields that will indicate if the record is changed, like version, timestamp etc.
+If the hash matches, the records are assumed to be the same (so no need to update the cache or clients).
+The default implementation takes a conservative approach by doing a sorted stringification of the record, and calculates a sha-1 of it.
+
+However, you may want to override this to save on CPU time.
+For example, if your records have a version or lastModified field, that may suffice as a hash value to indicate if a record has changed or not.
 
 This function will allow you to override the default implementation.
 

--- a/sync_cloud_api/setRecordHashFn.adoc
+++ b/sync_cloud_api/setRecordHashFn.adoc
@@ -1,0 +1,48 @@
+[[fh-sync-setrecordhashfn]]
+== $fh.sync.setRecordHashFn
+
+Define a function that will generate the hash value of a single record.
+This hash value will be used to determine if a record has changed or not.
+
+A default implementation is provided but because it knows nothing about the data, the generation process is relatively complicated.
+It could be slow if the each data record has a relatively complex structure.
+But it may be not necessary if the record already have certain fields that can determine if the record is changed, like version, timestamp etc.
+
+This function will allow you to override the default implementation.
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.setRecordHashFn(dataset_id, function generateHash(dataset_id, record){});
+----
+
+=== Parameters
+
+==== dataset_id
+* Description: the id of the dataset
+* Type: String
+
+==== generateHash
+* Description: The function that will be used to generate the hash of a dataset.
+* Type: Function
+* Invoked Parameters:
+** *dataset_id*
+*** Description: the id of the dataset
+*** Type: String
+** *record*
+*** Description: the record
+*** Type: Object
+
+=== Returns
+
+The hash value of the record.
+
+=== Example
+
+[source,javascript]
+----
+$fh.sync.setRecordHashFn("todo", function(dataset_id, record){
+  return record.lastModified;
+});
+----

--- a/sync_cloud_api/stop.adoc
+++ b/sync_cloud_api/stop.adoc
@@ -1,0 +1,37 @@
+[[fh-sync-stop]]
+== $fh.sync.stop
+
+Stop the sync process of the given dataset.
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.stop(dataset_id, callback)
+----
+
+=== Parameters
+
+==== dataset_id
+
+* Description: The id of the dataset.
+* Type: String
+
+==== callback
+
+* Description: The callback function.
+* Type: Function
+
+=== Example
+
+[source,javascript]
+----
+var datasetId = "todolist";
+$fh.sync.stop(datasetId, function(err){
+  if (err) {
+    console.error('sync stop failed due to error', err);
+  } else {
+    console.log('sync stop finished successfully');
+  }
+});
+----

--- a/sync_cloud_api/stop.adoc
+++ b/sync_cloud_api/stop.adoc
@@ -1,7 +1,7 @@
 [[fh-sync-stop]]
 == $fh.sync.stop
 
-Stop the sync process of the given dataset.
+Stop the syncing a specific Dataset with the Dataset Backend.
 
 === Usage
 

--- a/sync_cloud_api/stopAll.adoc
+++ b/sync_cloud_api/stopAll.adoc
@@ -1,0 +1,31 @@
+[[fh-sync-stopall]]
+== $fh.sync.stopAll
+
+Stop all the sync process of all the datasets.
+
+=== Usage
+
+[source,javascript]
+----
+$fh.sync.stopAll(callback)
+----
+
+=== Parameters
+
+==== callback
+
+* Description: The callback function.
+* Type: Function
+
+=== Example
+
+[source,javascript]
+----
+$fh.sync.stopAll(function(err){
+  if (err) {
+    console.error('sync stopAll failed due to error', err);
+  } else {
+    console.log('sync stopAll finished successfully');
+  }
+});
+----

--- a/sync_cloud_api/stopAll.adoc
+++ b/sync_cloud_api/stopAll.adoc
@@ -1,7 +1,7 @@
 [[fh-sync-stopall]]
 == $fh.sync.stopAll
 
-Stop all the sync process of all the datasets.
+Stop the syncing *all* Datasets with the Dataset Backend.
 
 === Usage
 

--- a/sync_cloud_api_7_0.adoc
+++ b/sync_cloud_api_7_0.adoc
@@ -9,7 +9,7 @@ The public methods and emitted events of the sync server are listed here.
 
 * link:./sync_cloud_api/setConfig.adoc[$fh.sync.setConfig]
 
-=== Lifecycle Management
+=== Sync Server Lifecycle
 
 You can use the following methods to control the lifecycle of the sync server.
 
@@ -21,13 +21,12 @@ You can use the following methods to control the lifecycle of the sync server.
 === Data Handlers
 
 Default data handlers are provided as part of the sync server.
-They will persist the data in the app's MongoDB.
+When using sync in an MBaaS, the default data handlers will use the MBaaS MongoDB.
+The Dataset Backend will be the Cloud App's database.
 
-The following methods can be used to override the default implementations.
+NOTE: If you are providing your own implementation, you should override *all* CRUDL handlers for a given dataset. This is to prevent unusual behaviour where some Dataset actions happen with default handlers, and some happen with overriden handlers.
 
-NOTE: If you are providing your own implementations, it's best to provide implementations of all the CURDL handlers for a given dataset.
-
-The following methods can be used to override data handlers for multiple datasets:
+The following methods can be used to override data handlers for *all* datasets:
 
 * link:./sync_cloud_api/globalHandleCreate.adoc[$fh.sync.globalHandleCreate]
 * link:./sync_cloud_api/globalHandleRead.adoc[$fh.sync.globalHandleRead]
@@ -46,11 +45,9 @@ The following methods can be used to override data handlers for a given dataset:
 === Collision Handlers
 
 Default collision handlers are provided as part of the sync server.
-They will persist collisions in the app's MongoDB.
+They will persist collisions in the Cloud App's database.
 
-The following methods can be used to override the default implementations:
-
-The following methods can be used to override collision handlers for multiple datasets:
+The following methods can be used to override collision handlers for *all* datasets:
 
 * link:./sync_cloud_api/globalHandleCollision.adoc[$fh.sync.globalHandleCollision]
 * link:./sync_cloud_api/globalListCollisions.adoc[$fh.sync.globalListCollisions]
@@ -65,6 +62,7 @@ The following methods can be used to override collision handlers for a given dat
 === Hash Functions
 
 Default implementations are provided to generate hash values of records and datasets.
+A record hash is used when comparing a cached record with the latest from the Dataset Backend.
 
 The following methods can be used to override the default implementations:
 
@@ -73,7 +71,8 @@ The following methods can be used to override the default implementations:
 
 === Request Interception
 
-These methods can be used to perform authentication or validation for each of the sync request:
+These methods can be used to intercept all sync requests before they reach the sync server.
+For example, you may want to add an autentication check by intercepting all sync requests, and reject any unauthorised requests.
 
 * link:./sync_cloud_api/globalInterceptRequest.adoc[$fh.sync.globalInterceptRequest]
 * link:./sync_cloud_api/interceptRequest.adoc[$fh.sync.interceptRequest]
@@ -90,6 +89,8 @@ The following events are emitted by the sync server.
 * *sync:ready*
 +
 This event will be emitted when the sync server is ready, after link:./sync_cloud_api/connect.adoc[$fh.sync.connect] is called.
+
+NOTE: When using the sync server from `fh-mbaas-api`, `sync.connect` is called automatically, and told to use the Cloud App's database. There is no need to call `sync.connect` in this case.
 
 To listen to the event, a listener should be attached to the event emitter. There are 2 ways to do it:
 

--- a/sync_cloud_api_7_0.adoc
+++ b/sync_cloud_api_7_0.adoc
@@ -1,3 +1,99 @@
-[[fh-sync]]
-= $fh.sync
+[[fh-sync-apis]]
+= $fh.sync APIs
+
+The public methods and emitted events of the sync server are listed here.
+
+== Methods
+
+=== Configuration
+
+* link:./sync_cloud_api/setConfig.adoc[$fh.sync.setConfig]
+
+=== Lifecycle Management
+
+You can use the following methods to control the lifecycle of the sync server.
+
+* link:./sync_cloud_api/connect.adoc[$fh.sync.connect]
+* link:./sync_cloud_api/init.adoc[$fh.sync.init]
+* link:./sync_cloud_api/stop.adoc[$fh.sync.stop]
+* link:./sync_cloud_api/stopAll.adoc[$fh.sync.stopAll]
+
+=== Data Handlers
+
+Default data handlers are provided as part of the sync server.
+They will persist the data in the app's MongoDB.
+
+The following methods can be used to override the default implementations.
+
+NOTE: If you are providing your own implementations, it's best to provide implementations of all the CURDL handlers for a given dataset.
+
+The following methods can be used to override data handlers for multiple datasets:
+
+* link:./sync_cloud_api/globalHandleCreate.adoc[$fh.sync.globalHandleCreate]
+* link:./sync_cloud_api/globalHandleRead.adoc[$fh.sync.globalHandleRead]
+* link:./sync_cloud_api/globalHandleUpdate.adoc[$fh.sync.globalHandleUpdate]
+* link:./sync_cloud_api/globalHandleDelete.adoc[$fh.sync.globalHandleDelete]
+* link:./sync_cloud_api/globalHandleList.adoc[$fh.sync.globalHandleList]
+
+The following methods can be used to override data handlers for a given dataset:
+
+* link:./sync_cloud_api/handleCreate.adoc[$fh.sync.handleCreate]
+* link:./sync_cloud_api/handleRead.adoc[$fh.sync.handleRead]
+* link:./sync_cloud_api/handleUpdate.adoc[$fh.sync.handleUpdate]
+* link:./sync_cloud_api/handleDelete.adoc[$fh.sync.handleDelete]
+* link:./sync_cloud_api/handleList.adoc[$fh.sync.handleList]
+
+=== Collision Handlers
+
+Default collision handlers are provided as part of the sync server.
+They will persist collisions in the app's MongoDB.
+
+The following methods can be used to override the default implementations:
+
+The following methods can be used to override collision handlers for multiple datasets:
+
+* link:./sync_cloud_api/globalHandleCollision.adoc[$fh.sync.globalHandleCollision]
+* link:./sync_cloud_api/globalListCollisions.adoc[$fh.sync.globalListCollisions]
+* link:./sync_cloud_api/globalRemoveCollision.adoc[$fh.sync.globalRemoveCollision]
+
+The following methods can be used to override collision handlers for a given dataset:
+
+* link:./sync_cloud_api/handleCollision.adoc[$fh.sync.handleCollision]
+* link:./sync_cloud_api/listCollisions.adoc[$fh.sync.listCollisions]
+* link:./sync_cloud_api/removeCollision.adoc[$fh.sync.removeCollision]
+
+=== Hash Functions
+
+Default implementations are provided to generate hash values of records and datasets.
+
+The following methods can be used to override the default implementations:
+
+* link:./sync_cloud_api/setGlobalHashFn.adoc[$fh.sync.setGlobalHashFn]
+* link:./sync_cloud_api/setRecordHashFn.adoc[$fh.sync.setRecordHashFn]
+
+=== Request Interception
+
+These methods can be used to perform authentication or validation for each of the sync request:
+
+* link:./sync_cloud_api/globalInterceptRequest.adoc[$fh.sync.globalInterceptRequest]
+* link:./sync_cloud_api/interceptRequest.adoc[$fh.sync.interceptRequest]
+
+=== Others
+
+* link:./sync_cloud_api/getEventEmitter.adoc[$fh.sync.getEventEmitter]
+* link:./sync_cloud_api/invoke.adoc[$fh.sync.invoke]
+
+== Events
+
+The following events are emitted by the sync server.
+
+* *sync:ready*
++
+This event will be emitted when the sync server is ready, after link:./sync_cloud_api/connect.adoc[$fh.sync.connect] is called.
+
+To listen to the event, a listener should be attached to the event emitter. There are 2 ways to do it:
+
+* use link:./sync_cloud_api/getEventEmitter.adoc[$fh.sync.getEventEmitter] method
+* use _$fh.events_ object
+
 

--- a/sync_cloud_api_7_0.adoc
+++ b/sync_cloud_api_7_0.adoc
@@ -1,0 +1,3 @@
+[[fh-sync]]
+= $fh.sync
+

--- a/sync_performance_scaling_guide.adoc
+++ b/sync_performance_scaling_guide.adoc
@@ -101,13 +101,37 @@ In this case, scaling the sync server will not really help, because the bottlene
 
 If you decide to scale the sync server, here are some of the options you can consider:
 
-=== Scaling on Dynofarm
+=== Scaling on Dynofarm (SAAS)
 
-If your app is running on the RHMAP dynofarm (all the SAAS customers are), you can use https://nodejs.org/docs/latest-v4.x/api/cluster.html[Nodejs Clustering] to create more workers.
+There are 2 options to scale the sync server on the RHAMP SAAS platform:
 
-If that's not enough, it is possible to create another app and point it to the same MongoDB to scale even further. 
+==== Use the Node.js Cluster Module
 
-//TODO: Add instruction of how to do that.
+To scale inside a single app, you can use https://nodejs.org/docs/latest-v4.x/api/cluster.html[Nodejs Clustering] to create more workers.
+
+==== Deploy More Apps
+
+Another option is to deploy more apps but point them to the same MongoDB as the existing app. 
+This will allow you to scale the sync server even further.
+
+To do this, you should:
+
+* Deploy a few more apps with the same code as the existing app
+* Find out the MongoDB connection string of the existing app
++
+It should be listed on the *Environment Varaible* screen in the App Studio, looking for a System Environment Variable called _FH_MONGODB_CONN_URL_
+* Copy the value, and create a new environment variable called _SYNC_MONGODB_URL_ in the newly created apps, and paste the MongoDB url as the value.
+* Redeploy the apps.
+
+With this approch, you can separate the HTTP request handling and sync data processing completely.
+
+For example, if there are 2 apps setup like this, App 1 and App 2, and App 1 is the cloud app that will accept HTTP requests. 
+You can then:
+
+* Set the worker concurrencies to 0 to disable all the sync workers in App 1. It will be dedicated to handle HTTP requests
+* Increase the concurrencies of sync workers in App 2, and reduce the sync interval values. It will make sure the sync data is processed as quickly as possible.
+
+Please check link:./sync_cloud_api/setConfig.adoc[$fh.sync.setConfig] for more inforamtion about how to configure the worker concurrencies.
 
 === Scaling on OpenShift
 


### PR DESCRIPTION
This PR will:

* Add documentations for all the APIs in the new sync framework. Each API has its own doc page and a new landing page is added to link them together.
* Add new instructions about how to scale the sync server to multiple apps on SAAS.

ping @david-martin for review.